### PR TITLE
Fix CTCP VERSION reply

### DIFF
--- a/src/dinoex_user.c
+++ b/src/dinoex_user.c
@@ -1174,7 +1174,7 @@ static int botonly_parse(int type, privmsginput *pi)
     if (check_ignore(pi->nick, pi->hostmask))
       return 0;
     notice(pi->nick, IRC_CTCP "VERSION" /* NOTRANSLATE */
-           "iroffer-dinoex"
+           " iroffer-dinoex"
            " " VERSIONLONG FEATURES ", " /* NOTRANSLATE */
            "https://iroffer.net/"
            "%s%s" IRC_CTCP, /* NOTRANSLATE */


### PR DESCRIPTION
Original reply: "CTCP reply VERSIONiroffer-dinoex 3.33 -..."
Corrected reply: "CTCP reply VERSION iroffer-dinoex 3.33 -..."

Fixes compatibility with Anope/Denora CTCP version checks.
Previously, MagIRC using Anope or Denora statserv would mark the bot version as UNKNOWN.
This change allows statserv to properly parse the version.